### PR TITLE
Enhanced Configuration Testing Script: Better Error Management Process, a Logical, Analytical and HIghly Readable Approach

### DIFF
--- a/config_common.py
+++ b/config_common.py
@@ -1,0 +1,137 @@
+import copy
+import json
+import os
+import tempfile
+import logging
+from typing import List, Type, Optional, Any
+
+from transformers import is_torch_available
+
+from .utils.test_configuration_utils import config_common_kwargs
+
+
+class ConfigTester:
+    def __init__(
+        self,
+        parent: Any,
+        config_class: Optional[Type] = None,
+        has_text_modality: bool = True,
+        common_properties: Optional[List[str]] = None,
+        **kwargs: Any
+    ):
+        self.parent = parent
+        self.config_class = config_class
+        self.has_text_modality = has_text_modality
+        self.inputs_dict = kwargs
+        self.common_properties = common_properties or [
+            "hidden_size", "num_attention_heads", "num_hidden_layers"
+        ]
+        if self.has_text_modality:
+            self.common_properties.append("vocab_size")
+
+    def create_and_test_config_common_properties(self):
+        config = self.config_class(**self.inputs_dict)
+        
+        for prop in self.common_properties:
+            if not hasattr(config, prop):
+                self.parent.fail(f"`{prop}` does not exist in the config class.")
+                
+            try:
+                setattr(config, prop, 1)
+                self.parent.assertEqual(
+                    getattr(config, prop), 1, 
+                    msg=f"`{prop}` expected to be 1, but got {getattr(config, prop)}"
+                )
+            except NotImplementedError:
+                logging.warning(f"Setter for `{prop}` not implemented.")
+
+    def create_and_test_config_to_json_string(self):
+        config = self.config_class(**self.inputs_dict)
+        obj = json.loads(config.to_json_string())
+        
+        for key, value in self.inputs_dict.items():
+            self.parent.assertEqual(
+                obj.get(key), value, 
+                msg=f"`{key}` expected to be {value}, but got {obj.get(key)}"
+            )
+
+    def create_and_test_config_to_json_file(self):
+        config_first = self.config_class(**self.inputs_dict)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            json_file_path = os.path.join(tmpdirname, "config.json")
+            config_first.to_json_file(json_file_path)
+            config_second = self.config_class.from_json_file(json_file_path)
+
+        self.parent.assertEqual(config_second.to_dict(), config_first.to_dict())
+
+    def create_and_test_config_from_and_save_pretrained(self):
+        config_first = self.config_class(**self.inputs_dict)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            config_first.save_pretrained(tmpdirname)
+            config_second = self.config_class.from_pretrained(tmpdirname)
+
+        self.parent.assertEqual(config_second.to_dict(), config_first.to_dict())
+
+        with self.parent.assertRaises(OSError):
+            invalid_path = f".{tmpdirname}"
+            logging.info(f"Attempting to load from invalid path: {invalid_path}")
+            self.config_class.from_pretrained(invalid_path)
+
+    def create_and_test_config_from_and_save_pretrained_subfolder(self):
+        config_first = self.config_class(**self.inputs_dict)
+
+        subfolder = "test"
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            sub_tmpdirname = os.path.join(tmpdirname, subfolder)
+            config_first.save_pretrained(sub_tmpdirname)
+            config_second = self.config_class.from_pretrained(tmpdirname, subfolder=subfolder)
+
+        self.parent.assertEqual(config_second.to_dict(), config_first.to_dict())
+
+    def create_and_test_config_with_num_labels(self):
+        config = self.config_class(**self.inputs_dict, num_labels=5)
+        
+        self.parent.assertEqual(len(config.id2label), 5)
+        self.parent.assertEqual(len(config.label2id), 5)
+
+        config.num_labels = 3
+        self.parent.assertEqual(len(config.id2label), 3)
+        self.parent.assertEqual(len(config.label2id), 3)
+
+    def check_config_can_be_init_without_params(self):
+        if self.config_class.is_composition:
+            with self.parent.assertRaises(ValueError):
+                self.config_class()
+        else:
+            config = self.config_class()
+            self.parent.assertIsNotNone(config)
+
+    def check_config_arguments_init(self):
+        kwargs = copy.deepcopy(config_common_kwargs)
+        config = self.config_class(**kwargs)
+        wrong_values = []
+
+        if "torch_dtype" in kwargs and is_torch_available():
+            import torch
+            if config.torch_dtype != torch.float16:
+                wrong_values.append(("torch_dtype", config.torch_dtype, torch.float16))
+        
+        for key, value in kwargs.items():
+            if key != "torch_dtype" and getattr(config, key) != value:
+                wrong_values.append((key, getattr(config, key), value))
+
+        if wrong_values:
+            errors = "\n".join([f"- {v[0]}: got {v[1]} instead of {v[2]}" for v in wrong_values])
+            raise ValueError(f"The following keys were not properly set in the config:\n{errors}")
+
+    def run_common_tests(self):
+        self.create_and_test_config_common_properties()
+        self.create_and_test_config_to_json_string()
+        self.create_and_test_config_to_json_file()
+        self.create_and_test_config_from_and_save_pretrained()
+        self.create_and_test_config_from_and_save_pretrained_subfolder()
+        self.create_and_test_config_with_num_labels()
+        self.check_config_can_be_init_without_params()
+        self.check_config_arguments_init()


### PR DESCRIPTION
 In this update, our priority was to enhance the configuration testing script to make it more resistant to outside factors, and easier to manage. Among them we have the improvement of more advanced error control mechanisms in order to ensure that any complication that may arise while running the configuration tests is well handled and well reported with the proper type of exception handling. 
 
 Logging has been incorporated into the application so as to ensure visibility in modeling the operations of the script especially in instances whereby specific configuration properties lack setters. This is helpful more so in debugging and generally offering a better understanding of the script’s pathway. 
 
 We also included stronger typing for the declaration to check compatibility to expected type data to be passed into the script. It also reduces the incidence of mistakes when turning even various configurations as the consistency of the script is improved. 
 
 Furthermore, the code has been made clean for sake of readability and since the project is relatively large it has been made cleaner by removing unnecessary lines and or code redundancy. This included:  Decomplexing of the logic In terms of improving the readability of the script and breaking them into smaller modules in a way that avoids redundancy. Such changes enhance not only the performance at the moment when it is made, but it also facilitates changes in the future. 
 
 Altogether, such enhancements enhance the purpose of the script as a tool that tests and validates different specifications of deep learning models.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
